### PR TITLE
ci: Add dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,37 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable
+# packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency review'
+on:
+  pull_request:
+    branches: [ "main" ]
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      # Write permissions for pull-requests are required for using the `comment-summary-in-pr` option, comment out if you aren't using this option
+      pull-requests: write
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: 'Dependency Review'
+      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+      # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
+      with:
+        comment-summary-in-pr: always
+      #   fail-on-severity: moderate
+      #   deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
+      #   retry-on-snapshot-warnings: true


### PR DESCRIPTION
## Summary
- Add `dependency-review` workflow (pinned `actions/checkout` and `actions/dependency-review-action` by SHA) to scan dependency manifest changes on PRs targeting `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)