### PR TITLE
Hash arguments with Streamlit's own key builder, and add type information

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,7 @@ else:
     model = result
 ```
 
+Arguments are hashed the way `st.cache_data` and `st.cache_resource` hash theirs, by delegating to Streamlit's own key builder: values such as dicts and DataFrames are keyed by content, a parameter whose name starts with an underscore is left out of the key, and an argument of a type Streamlit cannot hash raises `UnhashableParamError`.
+
 Note that, this decorator is a lightweight wrapper around `st.session_state` that acts like the code snippet above, and does not provide any additional features such as mutation guards that `st.cache_data` provides.
+Cached values live in the session state until the session ends, so there is no `ttl`, no `max_entries`, and no way to clear an entry.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ else:
     model = result
 ```
 
-Arguments are hashed the way `st.cache_data` and `st.cache_resource` hash theirs, by delegating to Streamlit's own key builder: values such as dicts and DataFrames are keyed by content, a parameter whose name starts with an underscore is left out of the key, and an argument of a type Streamlit cannot hash raises `UnhashableParamError`.
+Arguments are hashed the way `st.cache_data` and `st.cache_resource` hash theirs, by delegating to Streamlit's own key builder: values such as dicts and DataFrames are keyed by content, passing an argument positionally or by keyword gives the same key, a parameter whose name starts with an underscore is left out of the key, and an argument of a type Streamlit cannot hash raises `UnhashableParamError`. That exception is Streamlit's own, so its message suggests `@st.cache_resource`; the underscore it advises works the same way here.
 
 Note that, this decorator is a lightweight wrapper around `st.session_state` that acts like the code snippet above, and does not provide any additional features such as mutation guards that `st.cache_data` provides.
-Cached values live in the session state until the session ends, so there is no `ttl`, no `max_entries`, and no way to clear an entry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ readme = "README.md"
 license = "MIT"
 dynamic = ["version"]
 dependencies = [
-    "streamlit>=1.0.0",
+    # 1.25.0 is the floor for `_make_value_key()`'s current signature, which
+    # `calc_cache_key()` calls.
+    "streamlit>=1.25.0",
     "typing-extensions>=4.0.0; python_version < '3.10'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dev = [
     "ruff>=0.7.0",
     "mypy[faster-cache]>=1.15.0",
     "pytest>=7.3.1,<8",
-    "streamlit>=1.13.0",
+    "streamlit>=1.25.0",
     "bump-my-version>=1.1.1",
     "pre-commit>=4.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ requires-python = ">=3.9,!=3.9.7"  # 3.9.7 is excluded due to https://github.com
 readme = "README.md"
 license = "MIT"
 dynamic = ["version"]
-dependencies = ["streamlit>=1.0.0"]
+dependencies = [
+    "streamlit>=1.0.0",
+    "typing-extensions>=4.0.0; python_version < '3.10'",
+]
 
 [dependency-groups]
 dev = [

--- a/streamlit_session_memo/session_memo.py
+++ b/streamlit_session_memo/session_memo.py
@@ -1,41 +1,71 @@
+from __future__ import annotations
+
+import functools
+import sys
 import uuid
-from typing import Hashable
+from typing import Any, Callable, Hashable, NamedTuple, TypeVar
 
 import streamlit as st
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 CACHE_KEY_PREFIX = (
     uuid.uuid4().hex
 )  # To make the key more unique even when args or kwargs are so simple
 
 
-def get_fully_qualified_name(func):
+def get_fully_qualified_name(func: Callable[..., Any]) -> str:
     module_name = func.__module__
     qualname = func.__qualname__
     return f"{module_name}.{qualname}"
 
 
-def calc_cache_key(func, args, kwargs) -> Hashable:
+def calc_cache_key(
+    func: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> str:
     hashable_args = [a if isinstance(a, Hashable) else id(a) for a in args]
     hashable_kwargs = {
         k: v if isinstance(v, Hashable) else id(v) for k, v in kwargs.items()
     }
-    return (
-        CACHE_KEY_PREFIX,
-        get_fully_qualified_name(func),
-        tuple(hashable_args),
-        tuple(sorted(hashable_kwargs.items())),
+    # `st.session_state` accepts `str` and `int` keys and stringifies whatever it
+    # is given, so the tuple is stringified here rather than relying on that.
+    return str(
+        (
+            CACHE_KEY_PREFIX,
+            get_fully_qualified_name(func),
+            tuple(hashable_args),
+            tuple(sorted(hashable_kwargs.items())),
+        )
     )
 
 
-def st_session_memo(func):
-    def inner(*args, **kwargs):
+class CacheEntry(NamedTuple):
+    value: Any
+    # The arguments are kept alive by the entry that they are keyed by:
+    # `calc_cache_key()` falls back to `id()` for unhashable arguments, and CPython
+    # reuses the address of a freed object, so releasing them would let a later call
+    # with a different argument compute this entry's key and get this value back.
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+
+
+def st_session_memo(func: Callable[P, R]) -> Callable[P, R]:
+    @functools.wraps(func)
+    def inner(*args: P.args, **kwargs: P.kwargs) -> R:
         cache_key = calc_cache_key(func, args, kwargs)
 
         if cache_key in st.session_state:
-            return st.session_state[cache_key]
+            entry: CacheEntry = st.session_state[cache_key]
+            return entry.value
 
         value = func(*args, **kwargs)
-        st.session_state[cache_key] = value
+        st.session_state[cache_key] = CacheEntry(value, args, kwargs)
         return value
 
     return inner

--- a/streamlit_session_memo/session_memo.py
+++ b/streamlit_session_memo/session_memo.py
@@ -34,18 +34,21 @@ def get_fully_qualified_name(func: Callable[..., Any]) -> str:
 def calc_cache_key(
     func: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]
 ) -> str:
-    # The arguments are keyed by Streamlit's own key builder so that they are hashed
-    # exactly like `st.cache_data` and `st.cache_resource` hash theirs: by content, so
-    # that dicts and DataFrames key by value rather than by identity, skipping
-    # parameters whose name starts with an underscore, and raising
-    # `UnhashableParamError` for a type Streamlit cannot hash. It is a private API
-    # (`streamlit/runtime/caching/cache_utils.py`) whose signature took its current
-    # shape in Streamlit 1.25, the floor declared in `pyproject.toml`. The cache type
-    # only selects which decorator name that error message suggests.
-    # Streamlit annotates the parameter as `FunctionType`, but reads nothing off it
-    # that any callable lacks.
+    # `_make_value_key()` is the key builder behind `st.cache_data` and
+    # `st.cache_resource`, so arguments are hashed here exactly as those decorators
+    # hash theirs. It is a private API,
+    # https://github.com/streamlit/streamlit/blob/1.44.0/lib/streamlit/runtime/caching/cache_utils.py,
+    # whose signature took its current shape in Streamlit 1.25, the floor declared in
+    # `pyproject.toml`. The cache type only selects which decorator name the
+    # `UnhashableParamError` message suggests.
     value_key = _make_value_key(
-        CacheType.RESOURCE, cast("FunctionType", func), args, kwargs, None
+        CacheType.RESOURCE,
+        # Streamlit annotates this parameter as `FunctionType`, but only passes it to
+        # `inspect.signature()` and reads `__name__` off it in the error path.
+        cast("FunctionType", func),
+        args,
+        kwargs,
+        None,
     )
     return f"{CACHE_KEY_PREFIX}-{get_fully_qualified_name(func)}-{value_key}"
 

--- a/streamlit_session_memo/session_memo.py
+++ b/streamlit_session_memo/session_memo.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 import functools
 import sys
 import uuid
-from typing import Any, Callable, Hashable, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 
 import streamlit as st
+from streamlit.runtime.caching.cache_type import CacheType
+from streamlit.runtime.caching.cache_utils import _make_value_key
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
 else:
     from typing_extensions import ParamSpec
+
+if TYPE_CHECKING:
+    from types import FunctionType
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -29,30 +34,20 @@ def get_fully_qualified_name(func: Callable[..., Any]) -> str:
 def calc_cache_key(
     func: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]
 ) -> str:
-    hashable_args = [a if isinstance(a, Hashable) else id(a) for a in args]
-    hashable_kwargs = {
-        k: v if isinstance(v, Hashable) else id(v) for k, v in kwargs.items()
-    }
-    # `st.session_state` accepts `str` and `int` keys and stringifies whatever it
-    # is given, so the tuple is stringified here rather than relying on that.
-    return str(
-        (
-            CACHE_KEY_PREFIX,
-            get_fully_qualified_name(func),
-            tuple(hashable_args),
-            tuple(sorted(hashable_kwargs.items())),
-        )
+    # The arguments are keyed by Streamlit's own key builder so that they are hashed
+    # exactly like `st.cache_data` and `st.cache_resource` hash theirs: by content, so
+    # that dicts and DataFrames key by value rather than by identity, skipping
+    # parameters whose name starts with an underscore, and raising
+    # `UnhashableParamError` for a type Streamlit cannot hash. It is a private API
+    # (`streamlit/runtime/caching/cache_utils.py`) whose signature took its current
+    # shape in Streamlit 1.25, the floor declared in `pyproject.toml`. The cache type
+    # only selects which decorator name that error message suggests.
+    # Streamlit annotates the parameter as `FunctionType`, but reads nothing off it
+    # that any callable lacks.
+    value_key = _make_value_key(
+        CacheType.RESOURCE, cast("FunctionType", func), args, kwargs, None
     )
-
-
-class CacheEntry(NamedTuple):
-    value: Any
-    # The arguments are kept alive by the entry that they are keyed by:
-    # `calc_cache_key()` falls back to `id()` for unhashable arguments, and CPython
-    # reuses the address of a freed object, so releasing them would let a later call
-    # with a different argument compute this entry's key and get this value back.
-    args: tuple[Any, ...]
-    kwargs: dict[str, Any]
+    return f"{CACHE_KEY_PREFIX}-{get_fully_qualified_name(func)}-{value_key}"
 
 
 def st_session_memo(func: Callable[P, R]) -> Callable[P, R]:
@@ -61,11 +56,11 @@ def st_session_memo(func: Callable[P, R]) -> Callable[P, R]:
         cache_key = calc_cache_key(func, args, kwargs)
 
         if cache_key in st.session_state:
-            entry: CacheEntry = st.session_state[cache_key]
-            return entry.value
+            cached: R = st.session_state[cache_key]
+            return cached
 
         value = func(*args, **kwargs)
-        st.session_state[cache_key] = CacheEntry(value, args, kwargs)
+        st.session_state[cache_key] = value
         return value
 
     return inner

--- a/tests/test_session_memo.py
+++ b/tests/test_session_memo.py
@@ -50,6 +50,32 @@ class TestCalcCacheKey:
 
 
 @patch("streamlit_session_memo.session_memo.st")
+def test_st_session_memo_with_unhashable_arguments(st):
+    """Unhashable arguments are keyed by `id()`, and CPython reuses the address of a
+    freed object, so each cached argument must be kept alive to keep its key unique.
+    """
+    st.session_state = {}
+
+    @st_session_memo
+    def foo(config):
+        return config["name"]
+
+    # The dicts are not referenced by the caller, so a later one can be allocated at
+    # the address of an earlier one unless the cache holds on to them.
+    names = ["a", "b", "c", "d", "e", "f", "g", "h"]
+    assert [foo({"name": name}) for name in names] == names
+
+
+def test_st_session_memo_preserves_function_metadata():
+    @st_session_memo
+    def foo(a, b):
+        """Docstring of foo."""
+
+    assert foo.__name__ == "foo"
+    assert foo.__doc__ == "Docstring of foo."
+
+
+@patch("streamlit_session_memo.session_memo.st")
 def test_st_session_memo(st):
     st.session_state = {}
 

--- a/tests/test_session_memo.py
+++ b/tests/test_session_memo.py
@@ -70,6 +70,16 @@ class TestCalcCacheKey:
             foo, (), {"a": 1, "b": 2}
         )
 
+    def test_keyword_argument_order_is_significant(self):
+        # Inherited from Streamlit's key builder, which hashes keyword arguments in
+        # call order.
+        def foo(a, b):
+            pass
+
+        assert calc_cache_key(foo, (), {"a": 1, "b": 2}) != calc_cache_key(
+            foo, (), {"b": 2, "a": 1}
+        )
+
 
 @patch("streamlit_session_memo.session_memo.st")
 def test_st_session_memo_with_unhashable_arguments(st):

--- a/tests/test_session_memo.py
+++ b/tests/test_session_memo.py
@@ -2,6 +2,7 @@ import typing
 from unittest.mock import Mock, patch
 
 import pytest
+from streamlit.runtime.caching.cache_errors import UnhashableParamError
 
 from streamlit_session_memo.session_memo import calc_cache_key, st_session_memo
 
@@ -10,9 +11,6 @@ TEST_ARGS_LIST = [
     ((None,), {}),
     ((1,), {}),
     (("a",), {}),
-    ((), {1: 1}),
-    ((), {1: "a"}),
-    ((), {1: None}),
     ((), {"a": 1}),
     ((), {"a": "b"}),
     ((), {"a": None}),
@@ -39,31 +37,55 @@ class TestCalcCacheKey:
 
         assert calc_cache_key(foo, args, kwargs) != calc_cache_key(bar, args, kwargs)
 
-    def test_unhashable_arguments(self):
-        def foo():
+    def test_unhashable_arguments_are_keyed_by_content(self):
+        def foo(config):
             pass
 
-        assert calc_cache_key(foo, (object(),), {}) != calc_cache_key(
-            foo, (object(),), {}
+        assert calc_cache_key(foo, ({"a": 1},), {}) == calc_cache_key(
+            foo, ({"a": 1},), {}
         )
-        assert isinstance(calc_cache_key(foo, (object(),), {}), typing.Hashable)
+        assert calc_cache_key(foo, ({"a": 1},), {}) != calc_cache_key(
+            foo, ({"a": 2},), {}
+        )
+
+    def test_arguments_streamlit_cannot_hash(self):
+        def foo(config):
+            pass
+
+        with pytest.raises(UnhashableParamError):
+            calc_cache_key(foo, (object(),), {})
+
+    def test_underscore_prefixed_parameters_are_skipped(self):
+        def foo(_a, b):
+            pass
+
+        assert calc_cache_key(foo, (1, 2), {}) == calc_cache_key(foo, (9, 2), {})
+        assert calc_cache_key(foo, (1, 2), {}) != calc_cache_key(foo, (1, 9), {})
+
+    def test_positional_and_keyword_arguments_match(self):
+        def foo(a, b):
+            pass
+
+        assert calc_cache_key(foo, (1, 2), {}) == calc_cache_key(
+            foo, (), {"a": 1, "b": 2}
+        )
 
 
 @patch("streamlit_session_memo.session_memo.st")
 def test_st_session_memo_with_unhashable_arguments(st):
-    """Unhashable arguments are keyed by `id()`, and CPython reuses the address of a
-    freed object, so each cached argument must be kept alive to keep its key unique.
-    """
     st.session_state = {}
+
+    spy = Mock()
 
     @st_session_memo
     def foo(config):
+        spy()
         return config["name"]
 
-    # The dicts are not referenced by the caller, so a later one can be allocated at
-    # the address of an earlier one unless the cache holds on to them.
-    names = ["a", "b", "c", "d", "e", "f", "g", "h"]
-    assert [foo({"name": name}) for name in names] == names
+    # Each call builds an equal but distinct dict, as a rerun of a Streamlit script
+    # would.
+    assert [foo({"name": "a"}) for _ in range(3)] == ["a", "a", "a"]
+    spy.assert_called_once()
 
 
 def test_st_session_memo_preserves_function_metadata():


### PR DESCRIPTION
`calc_cache_key()` keyed unhashable arguments such as dicts by `id()`, and CPython reuses the address of a freed object once it is released, so a later call with a different argument could compute an existing entry's key and get that entry's value back. Measured on `main`, four distinct dicts produced only two distinct keys.

Argument hashing is delegated to Streamlit's own key builder now, so `st_session_memo` keys arguments exactly as `st.cache_data` and `st.cache_resource` key theirs: by content, so that equal dicts share an entry, with underscore-prefixed parameters left out of the key and `UnhashableParamError` raised for a type Streamlit cannot hash. Positional and keyword forms of the same call share an entry; keyword order, which the old key sorted away, now distinguishes entries as it does in Streamlit's decorators. This is a breaking change for callers passing an argument Streamlit cannot hash, which used to be cached by identity and now raises. That key builder is a private API whose signature took its current shape in Streamlit 1.25, so the `streamlit` floor moves from 1.0.0 to 1.25.0.

The decorator also preserves the wrapped function now: `functools.wraps` keeps `__name__` and `__doc__`, `ParamSpec` propagates the signature to call sites (`typing-extensions` supplies it below Python 3.10), and a `py.typed` marker exposes the annotations to consumers.

`uv.lock` is left alone here: the local `uv` rewrites all ~1900 lines (lock revision 1 to 3, plus `upload-time` on every entry), which belongs in its own PR. CI runs `uv sync` without `--locked`, so it re-resolves against the new floor.

The content keying and the preserved metadata are covered by tests that fail against the previous implementation.