### PR TITLE
ci: Build the package without installing the dev dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,9 +63,6 @@ jobs:
       with:
         python-version-file: "pyproject.toml"
 
-    - name: Install Python dependencies
-      run: uv sync --all-extras --dev
-
     - name: Package
       run: uv build
 


### PR DESCRIPTION
The `build` job runs `uv sync --all-extras --dev` before `uv build`, but `uv build` resolves its own isolated build environment and never touches the synced one. That install is now what makes the job fail, on `main` and on every open PR: `Set up Python` reads `requires-python = ">=3.9"` from `pyproject.toml` and so installs 3.14, and the locked `orjson` 3.10.16 that `mypy[faster-cache]` pulls in has no 3.14 wheel, so it falls back to a source build whose PyO3 rejects any interpreter above 3.13. Failing run: https://github.com/whitphx/streamlit-session-memo/actions/runs/31989728802/job/95271073850

Dropping the install leaves the job with what `uv build` actually needs, a checkout with the full history `hatch-vcs` reads the version from.