### PR TITLE
ci: Bump `pypa/gh-action-pypi-publish` to v1.14.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
         name: streamlit-session-memo-${{ github.ref_name }}
         path: dist/
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   github-release:
     name: >-

--- a/changelog.d/20260823_170731_t.yic.yt_bump_pypi_publish_action.md
+++ b/changelog.d/20260823_170731_t.yic.yt_bump_pypi_publish_action.md
@@ -1,0 +1,7 @@
+<!--
+A new scriv changelog fragment.
+-->
+
+### Chore
+
+- Bumped `pypa/gh-action-pypi-publish` to v1.14.2, whose Twine 7.0.0 accepts the `Metadata-Version: 2.5` that `hatchling` 1.32.0 now emits by default.


### PR DESCRIPTION
The v0.4.0 release failed to publish. `hatchling` 1.32.0 bumped its default core metadata version to 2.5, and this project does not pin `hatchling`, so the tag build produced a wheel with `Metadata-Version: 2.5`. The Twine 6.1.0 bundled in `pypa/gh-action-pypi-publish` v1.13.0 rejects that at `twine check` with `InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version`.

v1.14.2 bundles Twine 7.0.0, which accepts it. v1.14.0 and v1.14.1 still bundle Twine 6.1.0, so neither would fix this.

Failing run: https://github.com/whitphx/streamlit-session-memo/actions/runs/32004392186