### PR TITLE
ci: Use the changelog entry as the GitHub Release notes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,6 +164,11 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for sigstore
 
     steps:
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      with:
+        persist-credentials: false
+    - name: Install uv
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
     - name: Download all the dists
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
@@ -175,6 +180,11 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
+    - name: Extract this version's changelog entry
+      run: >-
+        uvx scriv print
+        --version "${GITHUB_REF_NAME#v}"
+        --output "${RUNNER_TEMP}/release-notes.md"
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
@@ -182,7 +192,7 @@ jobs:
         gh release create
         "$GITHUB_REF_NAME"
         --repo "$GITHUB_REPOSITORY"
-        --notes ""
+        --notes-file "${RUNNER_TEMP}/release-notes.md"
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,11 +164,20 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for sigstore
 
     steps:
+    # Must stay ahead of the dist download: on a workspace that is not yet a Git
+    # repo, checkout clears it before cloning, and `dist/` is gitignored.
     - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       with:
         persist-credentials: false
     - name: Install uv
       uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+    # Runs before the signing and upload steps so that a tag with no changelog
+    # entry fails here, rather than after the release is half-assembled.
+    - name: Extract this version's changelog entry
+      run: >-
+        uvx scriv==1.8.0 print
+        --version "${GITHUB_REF_NAME#v}"
+        --output "${RUNNER_TEMP}/release-notes.md"
     - name: Download all the dists
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
@@ -180,11 +189,6 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
-    - name: Extract this version's changelog entry
-      run: >-
-        uvx scriv print
-        --version "${GITHUB_REF_NAME#v}"
-        --output "${RUNNER_TEMP}/release-notes.md"
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/changelog.d/20260824_125447_t.yic.yt_release_notes_from_changelog.md
+++ b/changelog.d/20260824_125447_t.yic.yt_release_notes_from_changelog.md
@@ -1,0 +1,7 @@
+<!--
+A new scriv changelog fragment.
+-->
+
+### Chore
+
+- GitHub Releases now carry the version's `CHANGELOG.md` entry as their release notes, instead of an empty body.


### PR DESCRIPTION
`gh release create` is passed `--notes ""`, so every GitHub Release has an empty body: [v0.4.1](https://github.com/whitphx/streamlit-session-memo/releases/tag/v0.4.1) lists the signed artifacts and says nothing about what changed.

Now that `CHANGELOG.md` holds an entry per version, the release can carry it. The `github-release` job checks out the tagged tree, extracts that version's entry with `scriv print --version`, and passes it to `gh release create --notes-file`.
